### PR TITLE
feat: support multi line SQL statements in migrations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ features = []
 env_logger = "0.8"
 anyhow = "1"
 lazy_static = "1.4.0"
+mktemp = "0.4"

--- a/examples/quick_start.rs
+++ b/examples/quick_start.rs
@@ -15,12 +15,16 @@ mod tests {
     }
 }
 
-// Define migrations
+// Define migrations. These are applied atomically.
 lazy_static! {
     static ref MIGRATIONS: Migrations<'static> =
         Migrations::new(vec![
             M::up(include_str!("friend_car.sql")),
-            M::up("ALTER TABLE friend ADD COLUMN birthday TEXT;"),
+            // PRAGMA are better applied outside of migrations, see below for details.
+            M::up(r#"
+                  ALTER TABLE friend ADD COLUMN birthday TEXT;
+                  ALTER TABLE friend ADD COLUMN comment TEXT;
+                  "#),
             // In the future, if the need to change the schema arises, put
             // migrations here, like so:
             // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
@@ -31,7 +35,7 @@ lazy_static! {
 pub fn init_db() -> Result<Connection> {
     let mut conn = Connection::open("./my_db.db3")?;
 
-    // Update the database schema
+    // Update the database schema, atomically
     MIGRATIONS.latest(&mut conn)?;
 
     Ok(conn)
@@ -41,6 +45,12 @@ pub fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
 
     let conn = init_db().unwrap();
+
+    // Apply some PRAGMA. These are often better applied outside of migrations, as some needs to be
+    // executed for each connection (like `foreign_keys`) or to be executed outside transactions
+    // (`journal_mode` is a noop in a transaction).
+    conn.pragma_update(None, "journal_mode", &"WAL").unwrap();
+    conn.pragma_update(None, "foreign_keys", &"ON").unwrap();
 
     // Use the db 🥳
     conn.execute(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use log::{debug, info, trace, warn};
 use rusqlite::Connection;
 use rusqlite::NO_PARAMS;
 
+#[cfg(test)]
 mod tests;
 
 /// Enum listing possible errors.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 fn m_valid0() -> M<'static> {
-    M::up("PRAGMA journal_mode = WAL")
+    M::up("CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);")
 }
 fn m_valid10() -> M<'static> {
     M::up("CREATE TABLE t1(a, b);")

--- a/tests/multiline_test.rs
+++ b/tests/multiline_test.rs
@@ -1,0 +1,100 @@
+use rusqlite::{params, Connection};
+use rusqlite_migration::{Migrations, SchemaVersion, M};
+
+#[test]
+fn main_test() {
+    let db_file = mktemp::Temp::new_file().unwrap();
+    // Define a multiline migrations
+    let mut ms = vec![M::up(
+        r#"
+              CREATE TABLE friend (name TEXT PRIMARY KEY, email TEXT) WITHOUT ROWID;
+              PRAGMA journal_mode = WAL;
+              PRAGMA foreign_keys = ON;
+              ALTER TABLE friend ADD COLUMN birthday TEXT;
+              "#,
+    )];
+
+    {
+        let mut conn = Connection::open(&db_file).unwrap();
+
+        let migrations = Migrations::new(ms.clone());
+        migrations.latest(&mut conn).unwrap();
+
+        conn.pragma_update(None, "journal_mode", &"WAL").unwrap();
+        conn.pragma_update(None, "foreign_keys", &"ON").unwrap();
+
+        assert_eq!(
+            Ok(SchemaVersion::Inside(ms.len() - 1)),
+            migrations.current_version(&conn)
+        );
+
+        conn.execute(
+            "INSERT INTO friend (name, birthday) VALUES (?1, ?2)",
+            params!["John", "1970-01-01"],
+        )
+        .unwrap();
+
+        conn.query_row(
+            "SELECT * FROM pragma_journal_mode",
+            rusqlite::NO_PARAMS,
+            |row| {
+                assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        conn.query_row(
+            "SELECT * FROM pragma_foreign_keys",
+            rusqlite::NO_PARAMS,
+            |row| {
+                assert_eq!(row.get::<_, bool>(0), Ok(true));
+                Ok(())
+            },
+        )
+        .unwrap();
+    }
+
+    // Using a new connection to ensure the pragma were taken into account
+    {
+        let conn = Connection::open(&db_file).unwrap();
+
+        conn.query_row(
+            "SELECT * FROM pragma_journal_mode",
+            rusqlite::NO_PARAMS,
+            |row| {
+                assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO friend (name, birthday) VALUES (?1, ?2)",
+            params!["Anna", "1971-11-11"],
+        )
+        .unwrap();
+    }
+
+    // Later, we add things to the schema
+    ms.push(M::up("CREATE INDEX UX_friend_email ON friend(email)"));
+    ms.push(M::up("ALTER TABLE friend RENAME COLUMN birthday TO birth;"));
+
+    {
+        let mut conn = Connection::open(&db_file).unwrap();
+
+        let migrations = Migrations::new(ms.clone());
+        migrations.latest(&mut conn).unwrap();
+
+        assert_eq!(
+            Ok(SchemaVersion::Inside(2)),
+            migrations.current_version(&conn)
+        );
+
+        conn.execute(
+            "INSERT INTO friend (name, birth) VALUES (?1, ?2)",
+            params!["Alice", "2000-01-01"],
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
- Use `execute_batch` to allow for multiline statements
- It turns out that PRAGMAs are not always working well from inside a
  transaction, updated the documentation to make that clearer

Fixes #2