### PR TITLE
Rollback support / migrate to arbitrary version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 Cargo.lock
-.idea/
 
 # Output of some examples
 my_db.db3
+
+# Local IDE & editor files
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 Cargo.lock
+.idea/
 
 # Output of some examples
 my_db.db3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default-features = false
 features = []
 
 [dev-dependencies]
+simple-logging = "2.0.2"
 env_logger = "0.8"
 anyhow = "1"
 lazy_static = "1.4.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -89,14 +89,23 @@ impl std::error::Error for SchemaVersionError {}
 #[non_exhaustive]
 pub enum MigrationDefinitionError {
     /// Migration has no down version
-    DownNotDefined { to_version: usize },
+    DownNotDefined {
+        /// Index of the migration that caused the error
+        migration_index: usize,
+    },
 }
 
 impl fmt::Display for MigrationDefinitionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MigrationDefinitionError::DownNotDefined { to_version } => {
-                write!(f, "Migration to version {} cannot be reversed, downward direction is not defined.", to_version)
+            MigrationDefinitionError::DownNotDefined { migration_index } => {
+                write!(
+                    f,
+                    "Migration {} (version {} -> {}) cannot be reverted.",
+                    migration_index,
+                    migration_index,
+                    migration_index + 1
+                )
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,69 @@
+//! Custom error types
+
+use std::fmt;
+
+/// A typedef of the result returned by many methods.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Enum listing possible errors.
+#[derive(Debug, PartialEq)]
+#[allow(clippy::enum_variant_names)]
+#[non_exhaustive]
+pub enum Error {
+    /// Rusqlite error, query may indicate the attempted SQL query
+    RusqliteError { query: String, err: rusqlite::Error },
+    /// Error with the specified schema version
+    SpecifiedSchemaVersion(SchemaVersionError),
+}
+
+impl Error {
+    pub fn with_sql(e: rusqlite::Error, sql: &str) -> Error {
+        Error::RusqliteError {
+            query: String::from(sql),
+            err: e,
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO Format the error with fmt instead of debug
+        write!(f, "rusqlite_migrate error: {:?}", self)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::RusqliteError { query: _, err } => Some(err),
+            Error::SpecifiedSchemaVersion(e) => Some(e),
+        }
+    }
+}
+
+impl From<rusqlite::Error> for Error {
+    fn from(e: rusqlite::Error) -> Error {
+        Error::RusqliteError {
+            query: String::new(),
+            err: e,
+        }
+    }
+}
+
+/// Errors related to schema versions
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+#[non_exhaustive]
+pub enum SchemaVersionError {
+    /// Attempts to migrate to a version lower than the version currently in
+    /// the database. This is currently not supported
+    MigrateToLowerNotSupported,
+}
+
+impl fmt::Display for SchemaVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Attempts to migrate to a version lower than the version currently in the database. This is currently not supported.")
+    }
+}
+
+impl std::error::Error for SchemaVersionError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,81 +14,15 @@ limitations under the License.
 
 */
 
-use std::fmt;
-use std::result;
-
 use log::{debug, info, trace, warn};
 use rusqlite::Connection;
 use rusqlite::NO_PARAMS;
 
+mod errors;
+
 #[cfg(test)]
 mod tests;
-
-/// Enum listing possible errors.
-#[derive(Debug, PartialEq)]
-#[allow(clippy::enum_variant_names)]
-#[non_exhaustive]
-pub enum Error {
-    /// Rusqlite error, query may indicate the attempted SQL query
-    RusqliteError { query: String, err: rusqlite::Error },
-    /// Error with the specified schema version
-    SpecifiedSchemaVersion(SchemaVersionError),
-}
-
-impl Error {
-    fn with_sql(e: rusqlite::Error, sql: &str) -> Error {
-        Error::RusqliteError {
-            query: String::from(sql),
-            err: e,
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO Format the error with fmt instead of debug
-        write!(f, "rusqlite_migrate error: {:?}", self)
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::RusqliteError { query: _, err } => Some(err),
-            Error::SpecifiedSchemaVersion(e) => Some(e),
-        }
-    }
-}
-
-impl From<rusqlite::Error> for Error {
-    fn from(e: rusqlite::Error) -> Error {
-        Error::RusqliteError {
-            query: String::new(),
-            err: e,
-        }
-    }
-}
-
-/// Errors related to schema versions
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[allow(clippy::enum_variant_names)]
-#[non_exhaustive]
-pub enum SchemaVersionError {
-    /// Attempts to migrate to a version lower than the version currently in
-    /// the database. This is currently not supported
-    MigrateToLowerNotSupported,
-}
-
-impl fmt::Display for SchemaVersionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Attempts to migrate to a version lower than the version currently in the database. This is currently not supported.")
-    }
-}
-
-impl std::error::Error for SchemaVersionError {}
-
-/// A typedef of the result returned by many methods.
-pub type Result<T, E = Error> = result::Result<T, E>;
+pub use errors::{Error, Result, SchemaVersionError};
 
 /// One migration
 #[derive(Debug, PartialEq, Clone)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,8 @@ use rusqlite_migration::{Migrations, SchemaVersion, M};
 
 #[test]
 fn main_test() {
+    simple_logging::log_to_stderr(log::LevelFilter::Trace);
+
     let mut conn = Connection::open_in_memory().unwrap();
     // Define migrations
     let mut ms = vec![

--- a/tests/multiline_test.rs
+++ b/tests/multiline_test.rs
@@ -6,7 +6,7 @@ fn main_test() {
     simple_logging::log_to_stderr(log::LevelFilter::Trace);
 
     let db_file = mktemp::Temp::new_file().unwrap();
-    // Define a multiline migrations
+    // Define a multiline migration
     let mut ms = vec![M::up(
         r#"
               CREATE TABLE friend (name TEXT PRIMARY KEY, email TEXT) WITHOUT ROWID;

--- a/tests/multiline_test.rs
+++ b/tests/multiline_test.rs
@@ -3,6 +3,8 @@ use rusqlite_migration::{Migrations, SchemaVersion, M};
 
 #[test]
 fn main_test() {
+    simple_logging::log_to_stderr(log::LevelFilter::Trace);
+
     let db_file = mktemp::Temp::new_file().unwrap();
     // Define a multiline migrations
     let mut ms = vec![M::up(

--- a/tests/up_and_down.rs
+++ b/tests/up_and_down.rs
@@ -1,0 +1,108 @@
+use rusqlite::{params, Connection};
+use rusqlite_migration::{Migrations, SchemaVersion, M};
+
+#[test]
+fn main_test() {
+    simple_logging::log_to_stderr(log::LevelFilter::Trace);
+
+    let db_file = mktemp::Temp::new_file().unwrap();
+    // Define a multiline migrations
+    let ms = vec![
+        // 0
+        M::up("CREATE TABLE animals (id INTEGER, name TEXT);").down("DROP TABLE animals;"),
+        // 1
+        M::up("CREATE TABLE food (id INTEGER, name TEXT);").down("DROP TABLE food;"),
+        // 2
+        M::up("ALTER TABLE animals ADD COLUMN food_id INTEGER;")
+            .down("ALTER TABLE animals DROP COLUMN food_id;"),
+        // 3
+        M::up("CREATE TABLE habitats (id INTEGER, name TEXT);").down("DROP TABLE habitats;"),
+        // 4
+        M::up("ALTER TABLE animals ADD COLUMN habitat_id INTEGER;")
+            .down("ALTER TABLE animals DROP COLUMN habitat_id;"),
+        // 5
+    ];
+
+    {
+        let mut conn = Connection::open(&db_file).unwrap();
+
+        let migrations = Migrations::new(ms.clone());
+
+        assert_eq!(
+            Ok(SchemaVersion::NoneSet),
+            migrations.current_version(&conn)
+        );
+
+        migrations.to_version(&mut conn, 1).unwrap();
+
+        conn.execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
+            .unwrap();
+
+        // go back
+        migrations.to_version(&mut conn, 0).unwrap();
+
+        // the table is gone now
+        let _ = conn
+            .execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
+            .unwrap_err();
+
+        assert_eq!(
+            Ok(SchemaVersion::NoneSet),
+            migrations.current_version(&conn)
+        );
+    }
+
+    // Multiple steps
+    {
+        let mut conn = Connection::open(&db_file).unwrap();
+
+        let migrations = Migrations::new(ms.clone());
+
+        assert_eq!(
+            Ok(SchemaVersion::NoneSet),
+            migrations.current_version(&conn)
+        );
+
+        // Bad version, this should not change the DB
+        assert!(migrations.to_version(&mut conn, 6).is_err());
+
+        assert_eq!(
+            Ok(SchemaVersion::NoneSet),
+            migrations.current_version(&conn)
+        );
+
+        migrations.to_version(&mut conn, 5).unwrap();
+
+        conn.execute(
+            "INSERT INTO habitats (id, name) VALUES (?1, ?2)",
+            params![0, "Forest"],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO animals (name, habitat_id) VALUES (?1, ?2)",
+            params!["Fox", 0],
+        )
+        .unwrap();
+
+        // go back
+        migrations.to_version(&mut conn, 3).unwrap();
+
+        // the table is gone now
+        assert!(conn
+            .execute("INSERT INTO habitats (name) VALUES (?1)", params!["Beach"],)
+            .is_err());
+
+        conn.execute(
+            "INSERT INTO food (id, name) VALUES (?1, ?2)",
+            params![0, "Cheese"],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO animals (name, food_id) VALUES (?1, ?2)",
+            params!["Mouse", 0],
+        )
+        .unwrap();
+    }
+}

--- a/tests/up_and_down.rs
+++ b/tests/up_and_down.rs
@@ -7,17 +7,19 @@ fn main_test() {
 
     let ms = vec![
         // 0
-        M::up("CREATE TABLE animals (id INTEGER, name TEXT);").down("DROP TABLE animals;"),
+        M::up("CREATE TABLE animals (id INTEGER PRIMARY KEY, name TEXT);")
+            .down("DROP TABLE animals;"),
         // 1
-        M::up("CREATE TABLE food (id INTEGER, name TEXT);").down("DROP TABLE food;"),
+        M::up("CREATE TABLE food (id INTEGER PRIMARY KEY, name TEXT);").down("DROP TABLE food;"),
         // 2
-        M::up("ALTER TABLE animals ADD COLUMN food_id INTEGER;")
-            .down("ALTER TABLE animals DROP COLUMN food_id;"),
+        M::up("CREATE TABLE animal_food (animal_id INTEGER, food_id INTEGER);")
+            .down("DROP TABLE animal_food;"),
         // 3
-        M::up("CREATE TABLE habitats (id INTEGER, name TEXT);").down("DROP TABLE habitats;"),
+        M::up("CREATE TABLE habitats (id INTEGER PRIMARY KEY, name TEXT);")
+            .down("DROP TABLE habitats;"),
         // 4
-        M::up("ALTER TABLE animals ADD COLUMN habitat_id INTEGER;")
-            .down("ALTER TABLE animals DROP COLUMN habitat_id;"),
+        M::up("CREATE TABLE animal_habitat (animal_id INTEGER, habitat_id INTEGER);")
+            .down("DROP TABLE animal_habitat;"),
         // 5
     ];
 
@@ -83,8 +85,14 @@ fn main_test() {
         .unwrap();
 
         conn.execute(
-            "INSERT INTO animals (name, habitat_id) VALUES (?1, ?2)",
-            params!["Fox", 0],
+            "INSERT INTO animals (id, name) VALUES (?1, ?2)",
+            params![15, "Fox"],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO animal_habitat (animal_id, habitat_id) VALUES (?1, ?2)",
+            params![15, 0],
         )
         .unwrap();
 
@@ -96,15 +104,15 @@ fn main_test() {
             .execute("INSERT INTO habitats (name) VALUES (?1)", params!["Beach"],)
             .is_err());
 
-        conn.execute(
-            "INSERT INTO food (id, name) VALUES (?1, ?2)",
-            params![0, "Cheese"],
-        )
-        .unwrap();
+        conn.execute("INSERT INTO food (name) VALUES (?1)", params!["Cheese"])
+            .unwrap();
+
+        conn.execute("INSERT INTO animals (name) VALUES (?1)", params!["Mouse"])
+            .unwrap();
 
         conn.execute(
-            "INSERT INTO animals (name, food_id) VALUES (?1, ?2)",
-            params!["Mouse", 0],
+            "INSERT INTO animal_food (animal_id, food_id) VALUES (?1, ?2)",
+            params![1, 0],
         )
         .unwrap();
     }
@@ -120,8 +128,8 @@ fn test_errors() {
         // 1
         M::up("CREATE TABLE food (id INTEGER, name TEXT);"), // no down!!!
         // 2
-        M::up("ALTER TABLE animals ADD COLUMN food_id INTEGER;")
-            .down("ALTER TABLE animals DROP COLUMN food_id;"),
+        M::up("CREATE TABLE animal_food (animal_id INTEGER, food_id INTEGER);")
+            .down("DROP TABLE animal_food;"),
         // 3
     ];
 


### PR DESCRIPTION
Implementation of `.down()` as discussed in #5.

- Errors moved to their own module. There is a public re-export so nothing will break, it just makes the code easier to navigate.
- Added `.down()` method on migrations
- Added `.to_version()` method for migrating to an arbitrary version
- Added logging to integration tests, this makes debugging much easier. One new dev dependency.
- Improve logging somewhat
- New error variants
- Deprecated and hidden `MigrateToLowerNotSupported`. It's kept for back-compat, ideally should be removed.

I split it to smaller commits, so you can cherry-pick if you like, but I think all the changes make sense

Some things I noticed:
- If `SchemaVersion::Inside` was not off-by-one, it would be more straightforward to use. `.to_version()` uses the natural version numbering: 0=nothing run yet, 1 = after first migration, etc.
- Proposing to rename `.latest()` to `.to_latest()` or similar (just keep the two migrating methods consistent). "latest" doesn't evoke "migrate to latest version" in me at a first glance, more like something about getting the latest version number...