### PR TITLE
feat(#8): attempt to simplify to_version

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use crate::SchemaVersion;
+
 /// A typedef of the result returned by many methods.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -64,7 +66,10 @@ pub enum SchemaVersionError {
     #[doc(hidden)]
     MigrateToLowerNotSupported,
     /// Attempt to migrate to a version out of range for the supplied migrations
-    TargetVersionOutOfRange { specified: usize, highest: usize },
+    TargetVersionOutOfRange {
+        specified: SchemaVersion,
+        highest: SchemaVersion,
+    },
 }
 
 impl fmt::Display for SchemaVersionError {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,7 +63,7 @@ fn user_version_convert_test() {
     assert_eq!(Ok(()), migrations.to_latest(&mut conn));
     assert_eq!(Ok(1), user_version(&conn));
     assert_eq!(
-        Ok(SchemaVersion::Inside(0)),
+        Ok(SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())),
         migrations.current_version(&conn)
     );
     assert_eq!(1usize, migrations.current_version(&conn).unwrap().into());
@@ -79,7 +79,7 @@ fn user_version_migrate_test() {
     assert_eq!(Ok(()), migrations.to_latest(&mut conn));
     assert_eq!(Ok(1), user_version(&conn));
     assert_eq!(
-        Ok(SchemaVersion::Inside(0)),
+        Ok(SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())),
         migrations.current_version(&conn)
     );
 
@@ -87,7 +87,7 @@ fn user_version_migrate_test() {
     assert_eq!(Ok(()), migrations.to_latest(&mut conn));
     assert_eq!(Ok(2), user_version(&conn));
     assert_eq!(
-        Ok(SchemaVersion::Inside(1)),
+        Ok(SchemaVersion::Inside(NonZeroUsize::new(2).unwrap())),
         migrations.current_version(&conn)
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use rusqlite::{params, Connection};
 use rusqlite_migration::{Migrations, SchemaVersion, M};
 
@@ -8,7 +10,7 @@ fn main_test() {
     let mut conn = Connection::open_in_memory().unwrap();
     // Define migrations
     let mut ms = vec![
-        M::up("PRAGMA journal_mode=WAL;"),
+        M::up("CREATE TABLE t(a);"),
         M::up(include_str!("../examples/friend_car.sql")),
         M::up("ALTER TABLE friend ADD COLUMN birthday TEXT;"),
     ];
@@ -18,7 +20,7 @@ fn main_test() {
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(2)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(3).unwrap())),
             migrations.current_version(&conn)
         );
 
@@ -38,7 +40,7 @@ fn main_test() {
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(4)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(5).unwrap())),
             migrations.current_version(&conn)
         );
 
@@ -57,7 +59,7 @@ fn main_test() {
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(5)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(6).unwrap())),
             migrations.current_version(&conn)
         );
 

--- a/tests/multiline_test.rs
+++ b/tests/multiline_test.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use rusqlite::{params, Connection};
 use rusqlite_migration::{Migrations, SchemaVersion, M};
 
@@ -26,7 +28,7 @@ fn main_test() {
         conn.pragma_update(None, "foreign_keys", &"ON").unwrap();
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(ms.len() - 1)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(ms.len()).unwrap())),
             migrations.current_version(&conn)
         );
 
@@ -89,7 +91,7 @@ fn main_test() {
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(2)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(3).unwrap())),
             migrations.current_version(&conn)
         );
 

--- a/tests/up_and_down.rs
+++ b/tests/up_and_down.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use rusqlite::{params, Connection};
 use rusqlite_migration::{MigrationDefinitionError, Migrations, SchemaVersion, M};
 
@@ -20,7 +22,6 @@ fn main_test() {
         // 4
         M::up("CREATE TABLE animal_habitat (animal_id INTEGER, habitat_id INTEGER);")
             .down("DROP TABLE animal_habitat;"),
-        // 5
     ];
 
     {
@@ -39,7 +40,7 @@ fn main_test() {
             .unwrap();
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(0 /* this is off by one */)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())),
             migrations.current_version(&conn)
         );
 
@@ -130,7 +131,6 @@ fn test_errors() {
         // 2
         M::up("CREATE TABLE animal_food (animal_id INTEGER, food_id INTEGER);")
             .down("DROP TABLE animal_food;"),
-        // 3
     ];
 
     {
@@ -140,6 +140,11 @@ fn test_errors() {
 
         migrations.to_latest(&mut conn).unwrap();
 
+        assert_eq!(
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(3).unwrap())),
+            migrations.current_version(&conn)
+        );
+
         conn.execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
             .unwrap();
 
@@ -147,7 +152,7 @@ fn test_errors() {
         assert!(migrations.to_version(&mut conn, 0).is_err()); // oops
 
         assert_eq!(
-            Ok(SchemaVersion::Inside(2 /* off by one */)),
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(3).unwrap())),
             migrations.current_version(&conn)
         );
 


### PR DESCRIPTION
Use an Option<usize> to reflect the fact that we either have a corresponding migration, or we don’t and we want to remove all migrations ever applied.

Closes #8

The main change is:
```
-    pub fn to_version(&self, conn: &mut Connection, version: usize) -> Result<()> {
+    pub fn to_version(&self, conn: &mut Connection, version: Option<usize>) -> Result<()> {
```